### PR TITLE
Andrew/dislike (#171)

### DIFF
--- a/components/Card.vue
+++ b/components/Card.vue
@@ -1,5 +1,14 @@
 <template>
   <UCard variant="subtle" :class="['card-root', isSearched ? 'searched-card-bg' : '']" :ui="{ body: 'p-4 sm:p-4' }">
+    <!-- Confirmation Modal -->
+    <UModal v-model:open="showConfirmModal" title="Confirm Poor Result?"
+      description="Please confirm if you believe this card does not match your search. We use your judgement to improve our models. Thank you for your feedback!"
+      :ui="{ footer: 'justify-end' }">
+      <template #footer="{ close }">
+        <UButton label="Cancel" color="neutral" variant="outline" @click="close" />
+        <UButton label="Yes, This is a Poor Result" color="error" @click="confirmDislike" />
+      </template>
+    </UModal>
     <div class="card-image-wrapper">
       <!-- Card content: image + score -->
       <img :class="sizeClass" :src="getCardImageUrl(card.card_data)" :alt="card.card_data.name"
@@ -79,8 +88,7 @@
           <UTooltip v-if="!hideThumbsDownButton" text="I disagree with this result!" :popper="{ placement: 'top' }">
             <template #default>
               <UButton class="cursor-pointer" :color="isThumbsDownClicked ? 'error' : 'primary'" variant="soft"
-                icon="i-lucide-thumbs-down" size="sm" aria-label="Disagree with this result"
-                @click="isThumbsDownClicked = !isThumbsDownClicked" />
+                icon="i-lucide-thumbs-down" size="sm" aria-label="Disagree with this result" @click="handleDislike" />
             </template>
           </UTooltip>
         </div>
@@ -103,6 +111,7 @@ import type { PropType } from 'vue';
 import { computed, ref } from 'vue';
 import type { Card } from '~/models/cardModel';
 import { useRouter } from 'vue-router';
+import { useMutation } from '@tanstack/vue-query';
 import { DefaultLimitSimilarity } from '~/models/searchModel';
 import { getAffiliateLink } from '~/utils/tcgPlayer';
 import { getCardImageUrl } from '~/utils/scryfall';
@@ -151,7 +160,65 @@ const props = defineProps({
 const sizeClass = computed(() => `card-${props.size}`);
 
 const isThumbsDownClicked = ref(false);
+const showConfirmModal = ref(false);
 
+// Get the search query from route params
+const searchQuery = computed(() => {
+  // For AI/Commander search, the query is in route.query.query
+  if (route.query.query) {
+    return String(route.query.query);
+  }
+  // For similarity search, the query is the card_name
+  if (route.query.card_name) {
+    return String(route.query.card_name);
+  }
+  return '';
+});
+
+// Mutation for tracking dislike
+const dislikeMutation = useMutation({
+  mutationFn: async (data: { query: string; cardName: string }) => {
+    const response = await fetch('/api/metrics/dislike', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+      throw new Error('Failed to track dislike');
+    }
+    return response.json();
+  },
+  onError: (error) => {
+    console.error('Failed to track dislike:', error);
+  },
+});
+
+// Handle dislike button click - show confirmation modal
+function handleDislike() {
+  // Don't allow unclicking
+  if (isThumbsDownClicked.value) {
+    return;
+  }
+  if (!searchQuery.value || !props.card.card_data?.name) {
+    console.warn('Cannot track dislike: missing query or card name');
+    return;
+  }
+  // Show confirmation modal
+  showConfirmModal.value = true;
+}
+
+// Confirm dislike action
+function confirmDislike() {
+  showConfirmModal.value = false;
+  // Set the visual state (cannot be undone)
+  isThumbsDownClicked.value = true;
+
+  // Track the dislike
+  dislikeMutation.mutate({
+    query: searchQuery.value,
+    cardName: props.card.card_data.name,
+  });
+}
 // Navigation helper
 function navigateToCard(cardId: string | undefined) {
   // Save current search query to sessionStorage

--- a/components/ListSearchResults.vue
+++ b/components/ListSearchResults.vue
@@ -14,7 +14,7 @@
         <div v-for="(result, index) in sortedResults" :key="result.card_data.id">
           <CardComponent :card="result" :showCardInfo="true" :is-similarity-search="isSimilaritySearch"
             :is-searched="isSimilaritySearch && index === 0" :hide-progress-bar="isKeywordSearch"
-            :hide-thumbs-down-button="isKeywordSearch" />
+            :hide-thumbs-down-button="isKeywordSearch || isSimilaritySearch" />
         </div>
       </div>
     </template>

--- a/components/search/AISearch.vue
+++ b/components/search/AISearch.vue
@@ -1,5 +1,9 @@
 <template>
   <UForm :schema="schema" :state="state" class="flex-grow-1 space-y-4" @submit="onSubmit">
+    <!-- Honeypot field - hidden from users but visible to bots -->
+    <input v-model="honeypot" type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true"
+      style="position: absolute; left: -9999px; width: 1px; height: 1px;" />
+
     <UFormField name="query" class="mb-2">
       <div class="flex gap-2">
         <UInput ref="input" v-model="state.query" placeholder="Describe the cards you want..." icon="i-lucide-search"
@@ -69,9 +73,21 @@ const state = reactive<Partial<Schema>>({
   filters: parsedFilters.value || { 'selectedColorFilterOption': 'Contains At Least' }
 })
 
+// Honeypot field for bot detection
+const honeypot = ref('')
+
 const toast = useToast()
 
 async function onSubmit(event: FormSubmitEvent<Schema>) {
+  // Bot detection: if honeypot field is filled, reject the submission
+  if (honeypot.value) {
+    toast.add({
+      title: 'Invalid submission',
+      color: 'error'
+    });
+    return;
+  }
+
   try {
     const requestFilters = { ...event.data.filters } // shallow copy
 

--- a/components/search/CommanderSearch.vue
+++ b/components/search/CommanderSearch.vue
@@ -1,5 +1,9 @@
 <template>
   <UForm :schema="schema" :state="state" class="flex-grow-1 space-y-4" @submit="onSubmit">
+    <!-- Honeypot field - hidden from users but visible to bots -->
+    <input v-model="honeypot" type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true"
+      style="position: absolute; left: -9999px; width: 1px; height: 1px;" />
+
     <UFormField name="query" class="mb-2">
       <div class="flex gap-2">
         <UInput ref="input" v-model="state.query" placeholder="Describe the commander you want..."
@@ -57,9 +61,21 @@ const state = reactive<Partial<Schema>>({
   filters: parsedFilters.value || { selectedColorFilterOption: 'Contains At Least' }
 })
 
+// Honeypot field for bot detection
+const honeypot = ref('')
+
 const toast = useToast()
 
 async function onSubmit(event: FormSubmitEvent<Schema>) {
+  // Bot detection: if honeypot field is filled, reject the submission
+  if (honeypot.value) {
+    toast.add({
+      title: 'Invalid submission',
+      color: 'error'
+    });
+    return;
+  }
+
   try {
     const formData = {
       query: event.data.query,

--- a/components/search/KeywordSearch.vue
+++ b/components/search/KeywordSearch.vue
@@ -1,5 +1,9 @@
 <template>
   <UForm :schema="schema" :state="state" class="flex-grow-1 space-y-4" @submit="onSubmit">
+    <!-- Honeypot field - hidden from users but visible to bots -->
+    <input v-model="honeypot" type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true"
+      style="position: absolute; left: -9999px; width: 1px; height: 1px;" />
+
     <UFormField name="query" class="mb-2">
       <div class="flex gap-2">
         <UInput ref="input" v-model="state.query" placeholder="Search cards by keywords…" icon="i-lucide-search"
@@ -70,9 +74,21 @@ const state = reactive<Partial<Schema>>({
   filters: parsedFilters.value
 })
 
+// Honeypot field for bot detection
+const honeypot = ref('')
+
 const toast = useToast()
 
 async function onSubmit(event: FormSubmitEvent<Schema>) {
+  // Bot detection: if honeypot field is filled, reject the submission
+  if (honeypot.value) {
+    toast.add({
+      title: 'Invalid submission',
+      color: 'error'
+    });
+    return;
+  }
+
   try {
     const requestFilters = { ...event.data.filters } // shallow copy
 

--- a/components/search/SimilaritySearch.vue
+++ b/components/search/SimilaritySearch.vue
@@ -1,5 +1,9 @@
 <template>
   <UForm :schema="schema" :state="state" class="flex-grow-1 space-y-4" @submit="onSubmit">
+    <!-- Honeypot field - hidden from users but visible to bots -->
+    <input v-model="honeypot" type="text" name="website" autocomplete="off" tabindex="-1" aria-hidden="true"
+      style="position: absolute; left: -9999px; width: 1px; height: 1px;" />
+
     <UFormField name="card_name" class="mb-2">
       <div class="flex gap-2">
         <USelectMenu ref="autoComplete" v-model="state.card_name" v-model:search-term="searchTerm"
@@ -99,7 +103,21 @@ const filteredCards = computed(() => {
   return filtered;
 });
 
+// Honeypot field for bot detection
+const honeypot = ref('')
+
+const toast = useToast()
+
 async function onSubmit(event: FormSubmitEvent<Schema>) {
+  // Bot detection: if honeypot field is filled, reject the submission
+  if (honeypot.value) {
+    toast.add({
+      title: 'Invalid submission',
+      color: 'error'
+    });
+    return;
+  }
+
   try {
     const requestFilters = { ...event.data.filters } // shallow copy
 


### PR DESCRIPTION
* Moves search results into its own component ListSearchResults

* Adds similar cards section to card details page

* Carddetailssimlarresults title on left and sort on right when size permits

* Remove back to results button since its the same functionality as the back button in the browser

* Better light mode for cardDetails page, default text color for light mode is now black for readability (was gray)

* Use mythic orange color for Legendary Creature text for readability

* Fixes small text coloring issues

* Removes an unnecessary div and makes the cardSkeletons for similar search on card details page full width

* Removes color = neutral from other search components

* Removes Clipboard text from clipboard button

* Removes () from clipboard count

* Removes undefined filters before searching

* Adds a better light mode logo in navbar

* For first card of similarity search, always sets card name and type to white for readability

* Makes card names in clipboard clickable and brings to that cards page

* Fixes navbar logo always using dark mode variant

* Fixes hydration mismatch for navbar logo

* Revert "Fixes hydration mismatch for navbar logo"

This reverts commit 07a6d567b14231ecacddf3f658a8ff111424c298.

* Fixes hydration mismatch for navbar logo

* Adds confirm dislike modal and sends post request to server

* Hides thumbs down for similarity search

* Adds honeypots to prevent bot submissions